### PR TITLE
add expansion rule for pydm-ioc.cmd

### DIFF
--- a/RULES_EXPAND
+++ b/RULES_EXPAND
@@ -82,6 +82,12 @@ $(BUILD_TOP)/iocBoot/$(1)/edm-$(1).cmd: $(1).cfg
 	@if [ -f $(IOC_APPL_TOP)/iocBoot/templates/edm-ioc.cmd ]; then $(EXPAND) -c $(1).cfg $(IOC_APPL_TOP)/iocBoot/templates/edm-ioc.cmd $$@ IOCNAME=$(1) TOP=$(BUILD_TOP_ABS) IOCTOP=$(IOC_APPL_TOP); else echo "#!/bin/sh" > $$@; echo "echo No $(IOC_APPL_TOP)/iocBoot/templates/edm-ioc.cmd found!" >> $$@; fi
 	@chmod ug+w,a+x $$@
 
+# Expand $(BUILD_TOP)/iocBoot/$(1)/pydm-$(1).cmd
+$(BUILD_TOP)/iocBoot/$(1)/pydm-$(1).cmd: $(1).cfg
+	@echo Expanding $$@
+	@if [ -f $(IOC_APPL_TOP)/iocBoot/templates/pydm-ioc.cmd ]; then $(EXPAND) -c $(1).cfg $(IOC_APPL_TOP)/iocBoot/templates/pydm-ioc.cmd $$@ IOCNAME=$(1) TOP=$(BUILD_TOP_ABS) IOCTOP=$(IOC_APPL_TOP); else echo "#!/bin/sh" > $$@; echo "echo No $(IOC_APPL_TOP)/iocBoot/templates/pydm-ioc.cmd found!" >> $$@; fi
+	@chmod ug+w,a+x $$@
+
 # Create $(BUILD_TOP)/iocBoot/$(1)/IOC_APPL_TOP
 $(BUILD_TOP)/iocBoot/$(1)/IOC_APPL_TOP:
 	@echo Setting IOC_APPL_TOP to $(IOC_APPL_TOP) for $(1)


### PR DESCRIPTION
Add rules for the expansion of launch script for pydm-based screens.

Note: not sure how relevant that is, but there is a difference in the afs repo and this one.
I have a hard time making sense of it, as git is not too happy about the complete different history of these two repo.

```
[espov@psbuild-rhel7-01  repos]$ diff macro/expand.py macro_fork/expand.py
33c33
< keyword      = re.compile("^(ROOT|SUBSTR|UP|LOOP|IF|INCLUDE|TRANSLATE|COUNT|NAME)\(|^(CALC)\{")
---
> keyword      = re.compile("^(SUBSTR|UP|LOOP|IF|INCLUDE|TRANSLATE|COUNT|NAME)\(|^(CALC)\{")
44d43
<              ast.Mod: operator.mod,
57,58d55
<     if file == '-':
<         return sys.stdin
349,355c346
<                 n = self.ddict[node.id]
<                 if n[:2] == '0x':
<                     x = int(self.ddict[node.id], 16)
<                 elif n[0] == '0':
<                     x = int(self.ddict[node.id], 8)
<                 else:
<                     x = int(self.ddict[node.id], 10)
---
>                 x = int(self.ddict[node.id])
529,533d519
<                 else:
<                     argm = dbargs.search(lines[i][loc:])
<                     if argm != None:
<                         loc += argm.end(2)+1
<                         kw = "TAIL"
686,693d671
<                 elif kw == "ROOT":
<                     try:
<                         fn = cfg.ddict[argm.group(1)]
<                     except:
<                         fn = argm.group(1)
<                     if '.' in fn:
<                         fn = fn[:fn.index('.')]
<                     f.write(fn)
712,723d689
<                 elif kw == "TAIL":
<                     output = StringIO.StringIO()
<                     expand(cfg, [argm.group(1)], output, isfirst)
<                     value = output.getvalue()
<                     output.close()
<                     start  = argm.group(2)
<                     try:
<                         start  = cfg.ddict[start]
<                     except:
<                         pass
<                     start = int(start)
<                     f.write(value[start:])
812,815c778
<         if av[1] == '-':
<             fp = sys.stdout
<         else:
<             fp = open(av[1], 'w')
---
>         fp = open(av[1], 'w')

```