### PR TITLE
Merge afs ioc template macros from /afs/slac.stanford.edu/g/cd/swe/git/repos/slac/buildtools/ioc-template-macros.git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+realpath

--- a/Makefile.template
+++ b/Makefile.template
@@ -51,7 +51,7 @@ expandAll: $(TEMPS) $(EXPAND) config
 	$(EXPAND) $(IOC_APPL_TOP)/iocBoot/templates/ioc.sub-arch  $(IOC).sub-arch $(EXPAND_FLAGS)
 	$(EXPAND) $(IOC_APPL_TOP)/iocBoot/templates/ioc.sub-req   $(IOC).sub-req  $(EXPAND_FLAGS)
 	$(EXPAND) $(IOC_APPL_TOP)/iocBoot/templates/st.cmd        st.cmd          $(EXPAND_FLAGS)
-	chmod guo+x st.cmd
+	-chmod guo+x st.cmd
 
 clean realclean:: expandclean
 

--- a/RULES_EXPAND
+++ b/RULES_EXPAND
@@ -1,8 +1,8 @@
 #
 # RULES_EXPAND
 # Creates build rules needed to expand templated IOC config files
-#
-EXPAND       = /reg/g/pcds/controls/macro/expand
+RULES_EXPAND := $(lastword $(MAKEFILE_LIST))
+EXPAND       := $(dir $(RULES_EXPAND))/expand
 
 ifeq ($(BUILD_TOP),)
 BUILD_TOP = build
@@ -28,7 +28,7 @@ DIR_LIST += $(BUILD_TOP)/iocBoot
 default:	install
 all:		install
 
-.PHONY: install expand
+.PHONY: build install expand
 install: expand
 	@$(MAKE) -C $(BUILD_TOP) $@
 
@@ -55,6 +55,7 @@ IOC_DEP_PATTERN += $(addprefix $(BUILD_TOP)/iocBoot/__IOC__/, $$(IOC_DEP_SH))
 
 $(1)_DEP_LIST  = $$(subst __IOC__,$(1),$$(IOC_DEP_PATTERN))
 DIR_LIST      += $(BUILD_TOP)/iocBoot/$(1)
+.PHONY: $(BUILD_TOP)/iocBoot/$(1)
 
 expand: $(1).cfg $(BUILD_TOP)/iocBoot/$(1) $$($(1)_DEP_LIST)
 
@@ -68,43 +69,43 @@ $(1):	$$(DIR_LIST) $$($(1)_DEP_LIST)
 $(BUILD_TOP)/iocBoot/$(1)/Makefile:      $(IOC_APPL_TOP)/iocBoot/templates/Makefile
 	@echo Expanding $$@
 	@$(EXPAND) -c $(1).cfg $$(<) $$@ IOCNAME=$(1) TOP=$(BUILD_TOP_ABS) IOCTOP=$(IOC_APPL_TOP)
-	@chmod ug+w $$@
+	@-chmod ug+w $$@
 
 # Expand $(BUILD_TOP)/iocBoot/$(1)/st.cmd
 $(BUILD_TOP)/iocBoot/$(1)/st.cmd:      $(IOC_APPL_TOP)/iocBoot/templates/st.cmd
 	@echo Expanding $$@
 	@$(EXPAND) -c $(1).cfg $$(<) $$@ IOCNAME=$(1) TOP=$(BUILD_TOP_ABS) IOCTOP=$(IOC_APPL_TOP)
-	@chmod ug+w,a+x $$@
+	@-chmod ug+w,a+x $$@
 
 # Expand $(BUILD_TOP)/iocBoot/$(1)/edm-$(1).cmd
 $(BUILD_TOP)/iocBoot/$(1)/edm-$(1).cmd: $(1).cfg
 	@echo Expanding $$@
 	@if [ -f $(IOC_APPL_TOP)/iocBoot/templates/edm-ioc.cmd ]; then $(EXPAND) -c $(1).cfg $(IOC_APPL_TOP)/iocBoot/templates/edm-ioc.cmd $$@ IOCNAME=$(1) TOP=$(BUILD_TOP_ABS) IOCTOP=$(IOC_APPL_TOP); else echo "#!/bin/sh" > $$@; echo "echo No $(IOC_APPL_TOP)/iocBoot/templates/edm-ioc.cmd found!" >> $$@; fi
-	@chmod ug+w,a+x $$@
+	@-chmod ug+w,a+x $$@
 
 # Expand $(BUILD_TOP)/iocBoot/$(1)/pydm-$(1).cmd
 $(BUILD_TOP)/iocBoot/$(1)/pydm-$(1).cmd: $(1).cfg
 	@echo Expanding $$@
 	@if [ -f $(IOC_APPL_TOP)/iocBoot/templates/pydm-ioc.cmd ]; then $(EXPAND) -c $(1).cfg $(IOC_APPL_TOP)/iocBoot/templates/pydm-ioc.cmd $$@ IOCNAME=$(1) TOP=$(BUILD_TOP_ABS) IOCTOP=$(IOC_APPL_TOP); else echo "#!/bin/sh" > $$@; echo "echo No $(IOC_APPL_TOP)/iocBoot/templates/pydm-ioc.cmd found!" >> $$@; fi
-	@chmod ug+w,a+x $$@
+	@-chmod ug+w,a+x $$@
 
 # Create $(BUILD_TOP)/iocBoot/$(1)/IOC_APPL_TOP
 $(BUILD_TOP)/iocBoot/$(1)/IOC_APPL_TOP:
 	@echo Setting IOC_APPL_TOP to $(IOC_APPL_TOP) for $(1)
 	@echo "IOC_APPL_TOP=$(IOC_APPL_TOP)" > $$@
-	@chmod ug+w $$@
+	@-chmod ug+w $$@
 
 # Expand ioc.sub-arch and ioc.sub-req
 $(BUILD_TOP)/iocBoot/$(1)/$(1).%: $(IOC_APPL_TOP)/iocBoot/templates/ioc.%
 	@echo Expanding $$@
 	@$(EXPAND) -c $(1).cfg $$(<) $$(@) IOCNAME=$(1) TOP=$(BUILD_TOP_ABS) IOCTOP=$(IOC_APPL_TOP)
-	@chmod ug+w $$@
+	@-chmod ug+w $$@
 
 # Expand any *.sh files
 $(BUILD_TOP)/iocBoot/$(1)/%.sh: $(IOC_APPL_TOP)/iocBoot/templates/%.sh
 	@echo Expanding $$@
 	@$(EXPAND) -c $(1).cfg $$(<) $$(@) IOCNAME=$(1) TOP=$(BUILD_TOP_ABS) IOCTOP=$(IOC_APPL_TOP)
-	@chmod ug+w $$@
+	@-chmod ug+w $$@
 
 endef
 # End of EXPAND_template
@@ -127,19 +128,19 @@ $(foreach IOC, $(IOC_LIST),                      \
 $(BUILD_TOP)/Makefile: $(IOC_APPL_TOP)/Makefile
 	@echo Installing $@
 	@cp -u $< $@
-	@chmod ug+w $@
+	@-chmod ug+w $@
 
 # Ditto for the iocBoot Makefile
 $(BUILD_TOP)/iocBoot/Makefile: $(IOC_APPL_TOP)/iocBoot/Makefile
 	@echo Installing $@
 	@cp -u $< $@
-	@chmod ug+w $@
+	@-chmod ug+w $@
 
 # Create $(BUILD_TOP)/IOC_APPL_TOP
 $(BUILD_TOP)/IOC_APPL_TOP:
 	@echo Creating IOC_APPL_TOP
 	@echo "IOC_APPL_TOP=$(IOC_APPL_TOP)" > $@
-	@chmod ug+w $@
+	@-chmod ug+w $@
 
 # Build rule for directories
 $(DIR_LIST):
@@ -148,6 +149,7 @@ $(DIR_LIST):
 
 # These are our source files
 # No need to look for implicit rules for these
+$(makefile): ;
 %/iocBoot/templates/ioc.sub-arch: ;
 %/iocBoot/templates/ioc.sub-req: ;
 %/iocBoot/templates/Makefile: ;


### PR DESCRIPTION
OK, it's a bit more complicated than I expected - there's 3 git histories, it appears.
This repository has the full SVN history, so I think it's probably best to keep it.
(Separately there's: the two-commit git history version, then the git history version that starts in 2017 and adds `.gitignore` 🤷‍♂️ )

This merges in the changes from `/afs/slac.stanford.edu/g/cd/swe/git/repos/slac/buildtools/ioc-template-macros.git` and is entirely untested.

Anything look out of the ordinary here, @mcb64?