### PR TITLE
Fix up problem with one-line $$IFCALC.

### DIFF
--- a/expand.py
+++ b/expand.py
@@ -740,7 +740,7 @@ def expand(cfg, lines, f, isfirst=False):
                     output.close()
                     v = cfg.eval_expr(value)   # Yeah, if this isn't valid, just let it crash!
                     cfg.assign(args[0], str(v))
-                    if lines[i][loc] == '\n':
+                    if loc < len(lines[i]) and lines[i][loc] == '\n':
                         loc = loc + 1
                 elif kw == "CALC":
                     # Either $$CALC{expr} or $$CALC{expr,format}.


### PR DESCRIPTION
This is a simple one.  If we have an "$$IFCALC{expr}$$ELSE(CALC)...$$ENDIF(CALC)" on one line, trying to skip the possible newline at the end of the "..." will produce an out of range index.  Add a check that it's in range before looking.
