### PR TITLE
Add syncts script rules.

### DIFF
--- a/RULES_EXPAND
+++ b/RULES_EXPAND
@@ -20,6 +20,7 @@ IOC_DEP_PATTERN  += $(BUILD_TOP)/Makefile
 IOC_DEP_PATTERN  += $(BUILD_TOP)/iocBoot/__IOC__/edm-__IOC__.cmd
 IOC_DEP_PATTERN  += $(BUILD_TOP)/iocBoot/__IOC__/pydm-__IOC__.cmd
 IOC_DEP_PATTERN  += $(BUILD_TOP)/iocBoot/__IOC__/launchgui-__IOC__.cmd
+IOC_DEP_PATTERN  += $(BUILD_TOP)/iocBoot/__IOC__/syncts-__IOC__.cmd
 
 
 DIR_LIST += $(BUILD_TOP)
@@ -97,6 +98,12 @@ $(BUILD_TOP)/iocBoot/$(1)/launchgui-$(1).cmd: $(1).cfg
 	@if [ -f $(IOC_APPL_TOP)/iocBoot/templates/launchgui-ioc.cmd ]; then $(EXPAND) -c $(1).cfg $(IOC_APPL_TOP)/iocBoot/templates/launchgui-ioc.cmd $$@ IOCNAME=$(1) TOP=$(BUILD_TOP_ABS) IOCTOP=$(IOC_APPL_TOP); else echo "#!/bin/sh" > $$@; echo "echo No $(IOC_APPL_TOP)/iocBoot/templates/launchgui-ioc.cmd found!" >> $$@; fi
 	@-chmod ug+w,a+x $$@
 
+# Expand $(BUILD_TOP)/iocBoot/$(1)/syncts-$(1).cmd
+$(BUILD_TOP)/iocBoot/$(1)/syncts-$(1).cmd: $(1).cfg
+	@echo Expanding $$@
+	@if [ -f $(IOC_APPL_TOP)/iocBoot/templates/syncts-ioc.cmd ]; then $(EXPAND) -c $(1).cfg $(IOC_APPL_TOP)/iocBoot/templates/syncts-ioc.cmd $$@ IOCNAME=$(1) TOP=$(BUILD_TOP_ABS) IOCTOP=$(IOC_APPL_TOP); else echo "#!/bin/sh" > $$@; echo "echo No $(IOC_APPL_TOP)/iocBoot/templates/syncts-ioc.cmd found!" >> $$@; fi
+	@-chmod ug+w,a+x $$@
+
 # Create $(BUILD_TOP)/iocBoot/$(1)/IOC_APPL_TOP
 $(BUILD_TOP)/iocBoot/$(1)/IOC_APPL_TOP:
 	@echo Setting IOC_APPL_TOP to $(IOC_APPL_TOP) for $(1)
@@ -165,6 +172,7 @@ $(makefile): ;
 %/iocBoot/templates/edm-ioc.cmd: ;
 %/iocBoot/templates/pydm-ioc.cmd: ;
 %/iocBoot/templates/launchgui-ioc.cmd: ;
+%/iocBoot/templates/syncts-ioc.cmd: ;
 
 clean distclean realclean: expandclean
 


### PR DESCRIPTION
Added rules for building a templated syncts script.

IOCs that used the new INTERNAL timestamping mode of the timeStampFifo module currently have no way of syncing their timing automatically at startup of the IOC (unlike the SYNCED mode). Currently the Gige, Alvium, and Archon IOCs use the INTERNAL timestamp mode. The syncts-ioc.cmd is a template script that can either be run automate the syncing the timing when using INTERNAL mode.